### PR TITLE
Fix minute calculation for a running timer

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ const toHHMM = (input) => {
     total = Math.abs(total);
     const hours = Math.floor(total / 60);
     let minutes = total % 60;
-    if (minutes >= 59.5 && minutes <= 60) {
+    if (minutes >= 59.5 && minutes < 60) {
         minutes = Math.floor(minutes);
     } else {
         minutes = Math.round(minutes);

--- a/index.js
+++ b/index.js
@@ -32,12 +32,7 @@ const toHHMM = (input) => {
     const sign = total < 0 ? '-' : '';
     total = Math.abs(total);
     const hours = Math.floor(total / 60);
-    let minutes = total % 60;
-    if (minutes >= 59.5 && minutes < 60) {
-        minutes = Math.floor(minutes);
-    } else {
-        minutes = Math.round(minutes);
-    }
+    const minutes = Math.round(total % 60);
     const paddedMinutes = minutes.toString().padStart(2, '0');
     return `${sign}${hours}:${paddedMinutes}`;
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ const toHHMM = (input) => {
     const sign = total < 0 ? '-' : '';
     total = Math.abs(total);
     const hours = Math.floor(total / 60);
-    const minutes = Math.round(total % 60);
+    const minutes = Math.round(total) % 60;
     const paddedMinutes = minutes.toString().padStart(2, '0');
     return `${sign}${hours}:${paddedMinutes}`;
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,12 @@ const toHHMM = (input) => {
     const sign = total < 0 ? '-' : '';
     total = Math.abs(total);
     const hours = Math.floor(total / 60);
-    const minutes = Math.round(total) % 60;
+    let minutes = total % 60;
+    if (minutes >= 59.5 && minutes <= 60) {
+        minutes = Math.floor(minutes);
+    } else {
+        minutes = Math.round(minutes);
+    }
     const paddedMinutes = minutes.toString().padStart(2, '0');
     return `${sign}${hours}:${paddedMinutes}`;
 };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -56,6 +56,14 @@ describe('toHHMM', () => {
     expect(toHHMM(0.01)).toEqual('0:01')
   })
 
+  test('handles time ended in :59 correctly', () => {
+    expect(toHHMM(0.999)).toEqual('0:59')
+  })
+
+  test('handles time ended in :00 correctly', () => {
+    expect(toHHMM(1)).toEqual('1:00')
+  })
+
   test('handles leading and trailing space', () => {
     expect(toHHMM('          -1:30     +  1:44    ')).toEqual('0:14')
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,12 @@ export const toHHMM = (input?: number | string): string => {
   const sign = total < 0 ? '-' : ''
   total = Math.abs(total)
   const hours = Math.floor(total / 60)
-  const minutes = Math.round(total) % 60
+  let minutes = total % 60
+  if (minutes >= 59.5 && minutes < 60) {
+    minutes = Math.floor(minutes)
+  } else {
+    minutes = Math.round(minutes)
+  }
   const paddedMinutes = minutes.toString().padStart(2, '0')
 
   return `${sign}${hours}:${paddedMinutes}`


### PR DESCRIPTION
This is in response to an [issue](https://github.com/harvesthq/harvest-react-native/issues/1611) brought up on our mobile repo.

With a running timer, when the time changes from `1:59` to `2:00` for example, the time briefly displays at `1:00` instead of as `2:00` until another minute goes by, reverting back to the correct display time of `2:01`.

This is due to the use of `Math.round` which causes the minutes to display as `:00` a bit too soon before the hour calculation increases by 1 since it will round up when the remainder value is 59.5 or greater.

I added an `if` conditional to instead use `Math.floor` when the remainder value is between 59.5 and 60 to keep the value displaying as `:59` until the hour value increases by 1. 